### PR TITLE
Refactor timep.bash for improved script execution and profiling

### DIFF
--- a/timep.bash
+++ b/timep.bash
@@ -158,15 +158,7 @@ _timep_printTimeDiff() {
     case "${timep_runType}" in
         s)
             shift 1
-            timep_runFuncSrc0="timep_runFunc0() {
-$(cat "${timep_runCmdPath}")
-}"
-            eval "${timep_runFuncSrc0}"
-            if [[ -t 0 ]]; then
-                timep_runCmd="timep_runFunc0 ${@}"
-            else
-                timep_runCmd="cat | { timep_runFunc0 ${@}; }"
-            fi
+            timep_runCmd="$(<"${timep_runCmdPath}")"
         ;;
         f)
             if [[ -t 0 ]]; then
@@ -181,7 +173,9 @@ $(cat "${timep_runCmdPath}")
 # this will setup a DEBUG trap to measure runtime from every command, then will run the specified code.
 # the source code is generated and then sourced (instead of directly defined) so that things like the tmpdir/logfile path are hardcoded.
 # this allows timep to run without adding any new (and potengtially conflicting) variables to the code being run / time profiled.
-timep_runFuncSrc="timep_runFunc () (    
+timep_runFuncSrc=''
+[[ "${timep_runType}" == 'f' ]] && timep_runFuncSrc+='timep_runFunc () '
+timep_runFuncSrc+="(
 printf '\n
 ----------------------------------------------------------------------------
 ----------------------- RUNTIME BREAKDOWN BY COMMAND -----------------------
@@ -215,14 +209,26 @@ trap - DEBUG
 
 ) {fd_timep}>\"${timep_TMPDIR}\"/time.ALL"
 
-# source the wrapper function we just generated
-eval "${timep_runFuncSrc}"
+case "${timep_runType}" in
+    f)  
+        # source the wrapper function we just generated
+        eval "${timep_runFuncSrc}"
 
-# source it again by using declare -f in a command substitution
-# this may seem silly because it IS silly...but, it makes $LINENO give meaningful line numbers in the DEBUG trap
-. <(declare -f timep_runFunc)
+        # source it again by using declare -f in a command substitution
+        # this may seem silly because it IS silly...but, it makes $LINENO give meaningful line numbers in the DEBUG trap
+        . <(declare -f timep_runFunc)
 
-timep_runFunc
+        # now actually run it
+        timep_runFunc
+    ;;
+    s)  
+        echo "${timep_runFuncSrc}" >"${timep_TMPDIR}"/run.script.bash
+        chmod +x "${timep_TMPDIR}"/run.script.bash
+        "${timep_TMPDIR}"/run.script.bash "${@}"
+    ;;
+esac
+
+
 
 printf '\n\nThe code being time profiled has finished running!\ntimep will now process the logged timing data.\n\n' >&2
 


### PR DESCRIPTION
## Summary by Sourcery

Refactors the timep.bash script to improve the accuracy of line numbers reported in the DEBUG trap, and to handle shebangs correctly.

Enhancements:
- Improves the accuracy of line numbers reported in the DEBUG trap by sourcing the wrapper function using declare -f in a command substitution.
- Handles shebangs correctly when the run type is 's' by extracting the shebang and using it to execute the script.